### PR TITLE
fix: Fix concurrent Lease resource creating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: cargo doc --no-deps
 
       - name: Light tests
-        run: cargo test --lib --all
+        run: cargo test --all
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
@@ -56,4 +56,4 @@ jobs:
           k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
 
       - name: Heavy tests
-        run: cargo test --lib --all -- --ignored
+        run: cargo test --all -- --ignored

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -36,7 +36,7 @@ jobs:
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: kube-lease-manager-%p-%m.profraw
           RUST_LOG: kube_lease_manager=debug
-        run: cargo test --lib --all -- --include-ignored
+        run: cargo test --all -- --include-ignored
 
       - name: Generate coverage
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["kubernetes", "async", "lease", "leader", "election"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/alex-karpenko/kube-lease-manager"
-version = "0.1.6"
+version = "0.1.7"
 exclude = [
     ".github/**",
     ".vscode/**",


### PR DESCRIPTION
This PR fixes: 
- If `LeaseManager` tries to create `Lease` in `AutoCreate` mode with high number of concurrently runing managers, it may fail with `AlreadyExists` error;
- CI pipelines weren't running full test suite.