### PR TITLE
chore!: Update kube to v0.97 and thiserror to 2.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["kubernetes", "async", "lease", "leader", "election"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/alex-karpenko/kube-lease-manager"
-version = "0.5.0"
+version = "0.6.0"
 exclude = [
     ".github/**",
     ".vscode/**",
@@ -24,9 +24,9 @@ exclude = [
 
 [dependencies]
 k8s-openapi = { version = "0.23.0", default-features = false }
-kube = { version = "0.96.0", default-features = false, features = ["client"] }
+kube = { version = "0.97.0", default-features = false, features = ["client"] }
 rand = { version = "0.8.5" }
-thiserror = "1.0.61"
+thiserror = "2.0.3"
 tokio = { version = "1.38.0", default-features = false, features = [
     "sync",
     "time",
@@ -39,7 +39,7 @@ anyhow = "1.0.89"
 futures = { version = "0.3.31", default-features = false, features = [
     "async-await",
 ] }
-kube = { version = "0.96.0", default-features = false, features = [
+kube = { version = "0.97.0", default-features = false, features = [
     "rustls-tls",
     "runtime",
 ] }


### PR DESCRIPTION
Updates dependencies to support the latest kube-rs release and moves to new thiserror release.