### PR TITLE
feat: replace external Kubernetes dependency with testcontainers-managed k3s cluster for tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,4 +54,4 @@ jobs:
         env:
           CARGO_TEST_KUBE_VERSION: ${{ matrix.k8s }}
           DISABLE_CONTAINER_DESTRUCTORS: "true"
-        run: cargo test --all -- --include-ignored
+        run: cargo test --all -- --ignored

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,12 +50,8 @@ jobs:
       - name: Light tests
         run: cargo test --all
 
-      - uses: nolar/setup-k3d-k3s@v1
-        with:
-          version: ${{matrix.k8s}}
-          k3d-name: kube
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
-
       - name: Heavy tests
-        run: cargo test --all -- --ignored
+        env:
+          CARGO_TEST_KUBE_VERSION: ${{ matrix.k8s }}
+          DISABLE_CONTAINER_DESTRUCTORS: "true"
+        run: cargo test --all -- --include-ignored

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
           - 1.88.0
         k8s:
           - v1.31
+          - v1.34
           - latest
 
     steps:
@@ -55,3 +56,12 @@ jobs:
           CARGO_TEST_KUBE_VERSION: ${{ matrix.k8s }}
           DISABLE_CONTAINER_DESTRUCTORS: "true"
         run: cargo test --all -- --ignored
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -25,16 +25,11 @@ jobs:
           rustup override set nightly
 
       - uses: Swatinem/rust-cache@v2
-      - uses: nolar/setup-k3d-k3s@v1
-        with:
-          version: latest
-          k3d-name: kube
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
 
       - name: Test
         env:
           CI: true
+          DISABLE_CONTAINER_DESTRUCTORS: "true"
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: kube-lease-manager-%p-%m.profraw
           RUST_LOG: kube_lease_manager=debug

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 anyhow = "1.0.93"
+dtor = "1.0.4"
 futures = { version = "0.3.31", default-features = false, features = ["async-await"] }
 kube = { version = "3.0.0", default-features = false, features = ["rustls-tls", "runtime"] }
-rustls = { version = "0.23.23" }
+rustls = { version = "0.23.23", features = ["ring"] }
+testcontainers = { version = "0.27.3", default-features = false }
 tokio = { version = "1.38.2", default-features = false, features = ["rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.20" }
 uuid = { version = "1.10.0", features = ["v4"] }

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 
 [licenses]
-allow = ["MIT", "Apache-2.0", "ISC", "OpenSSL", "BSD-3-Clause"]
+allow = ["MIT", "Apache-2.0", "ISC", "BSD-3-Clause"]
 confidence-threshold = 0.93
 exceptions = [
     { allow = [

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -77,7 +77,7 @@ mod tests {
     use std::borrow::BorrowMut;
 
     use super::*;
-    use crate::manager::tests::init_tracing;
+    use crate::tests::init_tracing;
 
     #[test]
     fn ensure_every_next_is_longer() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,3 +173,6 @@ mod state;
 
 pub use error::*;
 pub use manager::*;
+
+#[cfg(test)]
+pub(crate) mod tests;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -785,11 +785,7 @@ mod tests {
     use super::*;
     use crate::tests::{LeaseDropper, TEST_NAMESPACE, init, setup_inconsistent_lease, sleep_secs};
     use futures::future::select_all;
-    use k8s_openapi::{
-        api::coordination::v1::Lease,
-        apimachinery::pkg::apis::meta::v1::MicroTime,
-        jiff::Timestamp,
-    };
+    use k8s_openapi::{api::coordination::v1::Lease, apimachinery::pkg::apis::meta::v1::MicroTime, jiff::Timestamp};
     use kube::{Api, api::DeleteParams};
     use std::collections::HashSet;
     use tokio::{join, select};

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -781,132 +781,18 @@ pub(crate) fn random_string(len: usize) -> String {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use super::*;
+    use crate::tests::{LeaseDropper, TEST_NAMESPACE, init, setup_inconsistent_lease, sleep_secs};
     use futures::future::select_all;
     use k8s_openapi::{
-        api::{
-            coordination::v1::{Lease, LeaseSpec},
-            core::v1::Namespace,
-        },
+        api::coordination::v1::Lease,
         apimachinery::pkg::apis::meta::v1::MicroTime,
         jiff::Timestamp,
     };
-    use kube::{
-        Api, Resource as _,
-        api::{DeleteParams, ObjectMeta, PostParams},
-    };
-    use std::{collections::HashSet, sync::OnceLock, thread};
-    use tokio::{join, runtime::Runtime, select, sync::OnceCell};
-
-    pub(crate) const TEST_NAMESPACE: &str = "kube-lease-test";
-
-    static INITIALIZED: OnceCell<bool> = OnceCell::const_new();
-    static TRACING: OnceLock<()> = OnceLock::new();
-
-    pub(crate) async fn init() -> Client {
-        let client = Client::try_default().await.unwrap();
-        INITIALIZED
-            .get_or_init(|| async {
-                create_namespace(client.clone()).await;
-                init_tracing();
-                true
-            })
-            .await;
-
-        client
-    }
-
-    pub(crate) fn init_tracing() {
-        TRACING.get_or_init(|| {
-            tracing_subscriber::fmt::init();
-        });
-    }
-
-    /// Implements Drop trait to delete Lease resource in case of test failure.
-    /// To use it, add the following statement at the beginning of a test function.
-    /// ```rust,no_run
-    /// let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
-    /// ```
-    pub(crate) struct LeaseDropper {
-        /// Name of the Lease resource
-        name: String,
-        /// Namespace
-        ns: String,
-    }
-
-    impl LeaseDropper {
-        /// The single possible constructor
-        pub fn new(name: impl Into<String>, ns: impl Into<String>) -> Self {
-            Self {
-                name: name.into(),
-                ns: ns.into(),
-            }
-        }
-    }
-
-    impl Drop for LeaseDropper {
-        fn drop(&mut self) {
-            let name = self.name.clone();
-            let ns = self.ns.clone();
-
-            debug!(lease = %name, namespace = %ns, "dropping possibly orphaned lease");
-            let _ = thread::spawn(move || {
-                Runtime::new().unwrap().block_on(async {
-                    let client = Client::try_default().await.unwrap();
-                    let api = Api::<Lease>::namespaced(client, &ns);
-                    let dp = DeleteParams::default();
-
-                    let _ = api.delete(&name, &dp).await;
-                });
-            })
-            .join();
-        }
-    }
-
-    /// Set up a Lease with inconsistent spec for testing.
-    ///
-    /// Pass either `renew_time` or `acquire_time` as `Some` and the other as `None`.
-    /// Passing both as `Some` is also fine.
-    pub(crate) async fn setup_inconsistent_lease(
-        lease_name: &str,
-        renew_time: Option<MicroTime>,
-        acquire_time: Option<MicroTime>,
-    ) -> Result<(), LeaseStateError> {
-        let client = init().await;
-        let api = Api::<Lease>::namespaced(client, TEST_NAMESPACE);
-
-        let pp = PostParams::default();
-        // Creates a Lease without holder identify but with renew_time/acquire_time
-        let spec = LeaseSpec {
-            renew_time,
-            acquire_time,
-            ..Default::default()
-        };
-
-        let data = Lease {
-            metadata: ObjectMeta {
-                name: Some(lease_name.to_string()),
-                ..Default::default()
-            },
-            spec: Some(spec),
-        };
-
-        api.create(&pp, &data).await.map_err(LeaseStateError::from)?;
-
-        Ok(())
-    }
-
-    /// Unattended namespace creation
-    async fn create_namespace(client: Client) {
-        let api = Api::<Namespace>::all(client);
-        let pp = PostParams::default();
-
-        let mut data = Namespace::default();
-        data.meta_mut().name = Some(String::from(TEST_NAMESPACE));
-
-        api.create(&pp, &data).await.unwrap_or_default();
-    }
+    use kube::{Api, api::DeleteParams};
+    use std::collections::HashSet;
+    use tokio::{join, select};
 
     async fn setup_simple_managers_vec(lease_name: &str, count: usize, create_lease: bool) -> Vec<LeaseManager> {
         const LEASE_DURATION_SECONDS: DurationSeconds = 2;
@@ -940,10 +826,6 @@ pub(crate) mod tests {
                 .unwrap();
         }
         managers
-    }
-
-    pub(crate) async fn sleep_secs(seconds: DurationSeconds) {
-        tokio::time::sleep(Duration::from_secs(seconds)).await
     }
 
     #[test]
@@ -1007,9 +889,9 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn grace_sleep_duration() {
-        let client = Client::try_default().await.unwrap();
+        let client = init().await;
         let manager = LeaseManager::new(
             client,
             "lease_name",
@@ -1055,7 +937,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn single_manager_watcher_step() {
         const LEASE_NAME: &str = "single-manager-watcher-step-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -1083,7 +965,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn single_manager_changed_loop() {
         const LEASE_NAME: &str = "single-manager-changed-loop-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -1111,7 +993,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn two_managers_1st_expires_then_2nd_locks() {
         const LEASE_NAME: &str = "two-managers-1st-expires-then-2nd-locks-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -1162,7 +1044,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn many_managers_1st_expires_then_someone_locks() {
         const LEASE_NAME: &str = "many-managers-1st-expires-then-someone-locks-test";
         const MANAGERS: usize = 100;
@@ -1249,7 +1131,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn create_lease() {
         const LEASE_NAME: &str = "create-lease-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -1310,7 +1192,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn two_managers_1st_releases_then_2nd_locks() {
         const LEASE_NAME: &str = "two-managers-1st-releases-then-2nd-locks-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -1361,7 +1243,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn single_watch_managers_handles_own_channel() {
         const LEASE_NAME: &str = "single-watch-managers-handle-channel-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -1402,7 +1284,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn two_managers_1st_uses_changed_2nd_watch() {
         const LEASE_NAME: &str = "two-managers-1st-uses-changed-2nd-watch-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -1464,7 +1346,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn many_managers_watch_one_by_one() {
         const LEASE_NAME: &str = "many-managers-watch-one-by-one-test";
         const NUMBER_OF_MANAGERS: usize = 10;
@@ -1563,7 +1445,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn lease_manager_builder() {
         const LEASE_NAME0: &str = "lease-manager-builder-test-0";
         const LEASE_NAME: &str = "lease-manager-builder-test";
@@ -1629,7 +1511,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn manager_read_inconsistent_lease_then_release_and_lock() {
         const LEASE_NAME: &str = "manager-read-inconsistent-lease-then-release-and-lock-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);

--- a/src/state.rs
+++ b/src/state.rs
@@ -403,7 +403,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn rough_create_delete() {
         const LEASE_NAME: &str = "rough-create-delete-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn auto_create_with_existing_inconsistent_lease() {
         const LEASE_NAME: &str = "auto-create-with-existing-inconsistent-lease-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -447,7 +447,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn use_existent_with_existing_inconsistent_lease() {
         const LEASE_NAME: &str = "use-existent-with-existing-inconsistent-lease-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn simple_soft_lock_soft_release() {
         const LEASE_NAME: &str = "simple-soft-lock-soft-release-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -502,7 +502,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn soft_lock_1st_soft_release_2nd() {
         const LEASE_NAME: &str = "soft-lock-1st-soft-release-2nd-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -557,7 +557,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn soft_lock_1st_force_release_2nd() {
         const LEASE_NAME: &str = "soft-lock-1st-force-release-2nd-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -594,7 +594,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn soft_lock_1st_soft_lock_2nd() {
         const LEASE_NAME: &str = "soft-lock-1st-soft-lock-2nd-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -649,7 +649,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn unattended_soft_lock_1st_soft_lock_2nd() {
         const LEASE_NAME: &str = "unattended-soft-lock-1st-soft-lock-2nd-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -691,7 +691,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn unattended_soft_lock_1st_force_lock_2nd() {
         const LEASE_NAME: &str = "unattended-soft-lock-1st-force-lock-2nd-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -734,7 +734,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn deleted_lease_state() {
         const LEASE_NAME: &str = "deleted-lease-state-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -753,7 +753,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn update_lease_with_conflict() {
         const LEASE_NAME: &str = "update-lease-with-conflict-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);
@@ -787,7 +787,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "uses k8s current-context"]
+    #[ignore = "needs docker"]
     async fn unattended_inconsistent_lease_soft_lock_release() {
         const LEASE_NAME: &str = "inconsistent-lease-soft-lock-release-test";
         let _dropper = LeaseDropper::new(LEASE_NAME, TEST_NAMESPACE);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,192 @@
+#[path = "../../tests/common/k3s.rs"]
+mod k3s;
+
+use k3s::K3s;
+use dtor::dtor;
+use k8s_openapi::{
+    api::{
+        coordination::v1::{Lease, LeaseSpec},
+        core::v1::Namespace,
+    },
+    apimachinery::pkg::apis::meta::v1::MicroTime,
+};
+use kube::{
+    Api, Client, Resource as _,
+    api::{DeleteParams, ObjectMeta, PostParams},
+};
+use std::{env, sync::OnceLock, thread};
+use testcontainers::{ContainerAsync, ImageExt as _, runners::AsyncRunner as _};
+use tokio::{
+    runtime::Runtime,
+    sync::{OnceCell, RwLock},
+};
+use tracing::debug;
+
+use crate::{DurationSeconds, state::LeaseStateError};
+
+pub(crate) const TEST_NAMESPACE: &str = "kube-lease-test";
+
+const DISABLE_CONTAINER_DESTRUCTORS_ENV_NAME: &str = "DISABLE_CONTAINER_DESTRUCTORS";
+
+static K3S_CLUSTER_CONTAINER: OnceCell<RwLock<Option<ContainerAsync<K3s>>>> = OnceCell::const_new();
+static INITIALIZED: OnceCell<bool> = OnceCell::const_new();
+static TRACING: OnceLock<()> = OnceLock::new();
+
+pub(crate) async fn init_crypto_provider() {
+    static CRYPTO_PROVIDER_INITIALIZED: OnceCell<()> = OnceCell::const_new();
+    CRYPTO_PROVIDER_INITIALIZED
+        .get_or_init(|| async {
+            if rustls::crypto::CryptoProvider::get_default().is_none() {
+                rustls::crypto::ring::default_provider()
+                    .install_default()
+                    .expect("Error initializing rustls provider");
+            }
+        })
+        .await;
+}
+
+pub(crate) async fn get_test_kube_client() -> anyhow::Result<Client> {
+    let guard = get_k3s_cluster().await.read().await;
+    let cluster = guard.as_ref().unwrap();
+    K3s::get_client(cluster).await
+}
+
+async fn get_k3s_cluster() -> &'static RwLock<Option<ContainerAsync<K3s>>> {
+    K3S_CLUSTER_CONTAINER
+        .get_or_init(|| async {
+            init_crypto_provider().await;
+
+            let runtime_folder = std::env::temp_dir()
+                .join(format!("kube-lease-k3s-{}", std::process::id()))
+                .to_string_lossy()
+                .into_owned();
+            tokio::fs::create_dir_all(&runtime_folder).await.unwrap();
+
+            let container = K3s::new(runtime_folder)
+                .with_userns_mode("host")
+                .with_privileged(true)
+                .start()
+                .await
+                .unwrap();
+
+            RwLock::new(Some(container))
+        })
+        .await
+}
+
+pub(crate) async fn init() -> Client {
+    let client = get_test_kube_client().await.unwrap();
+    INITIALIZED
+        .get_or_init(|| async {
+            create_namespace(client.clone()).await;
+            init_tracing();
+            true
+        })
+        .await;
+    client
+}
+
+pub(crate) fn init_tracing() {
+    TRACING.get_or_init(|| {
+        tracing_subscriber::fmt::init();
+    });
+}
+
+pub(crate) async fn sleep_secs(seconds: DurationSeconds) {
+    tokio::time::sleep(std::time::Duration::from_secs(seconds)).await
+}
+
+pub(crate) struct LeaseDropper {
+    name: String,
+    ns: String,
+}
+
+impl LeaseDropper {
+    pub fn new(name: impl Into<String>, ns: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ns: ns.into(),
+        }
+    }
+}
+
+impl Drop for LeaseDropper {
+    fn drop(&mut self) {
+        let name = self.name.clone();
+        let ns = self.ns.clone();
+
+        debug!(lease = %name, namespace = %ns, "dropping possibly orphaned lease");
+        let _ = thread::spawn(move || {
+            Runtime::new().unwrap().block_on(async {
+                if let Ok(client) = get_test_kube_client().await {
+                    let api = Api::<Lease>::namespaced(client, &ns);
+                    let dp = DeleteParams::default();
+                    let _ = api.delete(&name, &dp).await;
+                }
+            });
+        })
+        .join();
+    }
+}
+
+pub(crate) async fn setup_inconsistent_lease(
+    lease_name: &str,
+    renew_time: Option<MicroTime>,
+    acquire_time: Option<MicroTime>,
+) -> Result<(), LeaseStateError> {
+    let client = init().await;
+    let api = Api::<Lease>::namespaced(client, TEST_NAMESPACE);
+
+    let pp = PostParams::default();
+    let spec = LeaseSpec {
+        renew_time,
+        acquire_time,
+        ..Default::default()
+    };
+
+    let data = Lease {
+        metadata: ObjectMeta {
+            name: Some(lease_name.to_string()),
+            ..Default::default()
+        },
+        spec: Some(spec),
+    };
+
+    api.create(&pp, &data).await.map_err(LeaseStateError::from)?;
+
+    Ok(())
+}
+
+async fn create_namespace(client: Client) {
+    let api = Api::<Namespace>::all(client);
+    let pp = PostParams::default();
+
+    let mut data = Namespace::default();
+    data.meta_mut().name = Some(String::from(TEST_NAMESPACE));
+
+    api.create(&pp, &data).await.unwrap_or_default();
+}
+
+#[dtor(unsafe)]
+fn shutdown_test_containers() {
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    if env::var(DISABLE_CONTAINER_DESTRUCTORS_ENV_NAME).is_err() {
+        let _ = thread::spawn(|| {
+            Runtime::new().unwrap().block_on(async {
+                let _guard = LOCK.lock().await;
+
+                if let Some(k3s) = K3S_CLUSTER_CONTAINER.get() {
+                    let mut k3s = k3s.write().await;
+                    if k3s.is_some() {
+                        let old = (*k3s).take().unwrap();
+                        old.stop().await.unwrap();
+                        old.rm().await.unwrap();
+                        *k3s = None;
+                    }
+                }
+            });
+        })
+        .join();
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,8 +1,8 @@
 #[path = "../../tests/common/k3s.rs"]
 mod k3s;
 
-use k3s::K3s;
 use dtor::dtor;
+use k3s::K3s;
 use k8s_openapi::{
     api::{
         coordination::v1::{Lease, LeaseSpec},

--- a/tests/auto.rs
+++ b/tests/auto.rs
@@ -1,15 +1,15 @@
-use kube::Client;
+mod common;
+
 use kube_lease_manager::{LeaseManagerBuilder, Result};
 use std::time::Duration;
 
 #[tokio::test]
-#[ignore = "uses k8s current-context"]
+#[ignore = "needs docker"]
 async fn auto() -> Result<()> {
     tracing_subscriber::fmt::init();
-    // Use the default Kube client.
-    let client = Client::try_default().await?;
+    let client = common::get_test_kube_client().await.unwrap();
     // Create the simplest LeaseManager with reasonable defaults using a convenient builder.
-    // It uses a Lease resource called `test-watch-lease`.
+    // It uses a Lease resource called `test-auto-lease`.
     let manager = LeaseManagerBuilder::new(client, "test-auto-lease").build().await?;
 
     let (mut channel, task) = manager.watch().await;

--- a/tests/common/k3s.rs
+++ b/tests/common/k3s.rs
@@ -1,0 +1,161 @@
+#![allow(dead_code)]
+
+use kube::{
+    Config,
+    config::{KubeConfigOptions, Kubeconfig},
+};
+use rustls::crypto::CryptoProvider;
+use std::{borrow::Cow, collections::HashMap, io, path::Path};
+use testcontainers::{
+    ContainerAsync, Image,
+    core::{ContainerPort, Mount, WaitFor},
+};
+
+pub const K3S_IMAGE_NAME: &str = "rancher/k3s";
+pub const K3S_API_PORT: ContainerPort = ContainerPort::Tcp(6443);
+
+pub const K3S_IMAGE_TAG_ENV_VAR: &str = "CARGO_TEST_K3S_IMAGE_TAG";
+pub const KUBE_VERSION_ENV_VAR: &str = "CARGO_TEST_KUBE_VERSION";
+pub const KUBE_VERSION_DEFAULT: &str = "1.36";
+
+const AVAILABLE_K3S_IMAGE_TAGS: [(&str, &str); 11] = [
+    ("1.36", "v1.36.1-k3s1"),
+    ("1.35", "v1.35.5-k3s1"),
+    ("1.34", "v1.34.8-k3s1"),
+    ("1.33", "v1.33.12-k3s1"),
+    ("1.32", "v1.32.13-k3s1"),
+    ("1.31", "v1.31.14-k3s1"),
+    ("1.30", "v1.30.13-k3s1"),
+    ("1.29", "v1.29.15-k3s1"),
+    ("1.28", "v1.28.15-k3s1"),
+    ("1.27", "v1.27.16-k3s1"),
+    ("1.26", "v1.26.15-k3s1"),
+];
+
+#[derive(Debug, Clone)]
+pub struct K3s {
+    kubeconfig_folder: Mount,
+    tag: String,
+}
+
+impl Image for K3s {
+    fn name(&self) -> &str {
+        K3S_IMAGE_NAME
+    }
+
+    fn tag(&self) -> &str {
+        self.tag.as_str()
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr("Node controller sync successful")]
+    }
+
+    fn env_vars(&self) -> impl IntoIterator<Item = (impl Into<Cow<'_, str>>, impl Into<Cow<'_, str>>)> {
+        vec![(String::from("K3S_KUBECONFIG_MODE"), String::from("644"))]
+    }
+
+    fn mounts(&self) -> impl IntoIterator<Item = &Mount> {
+        vec![&self.kubeconfig_folder]
+    }
+
+    fn cmd(&self) -> impl IntoIterator<Item = impl Into<Cow<'_, str>>> {
+        vec![
+            "server",
+            "--snapshotter=native",
+            "--disable-network-policy",
+            "--disable=traefik",
+            "--disable=coredns",
+            "--disable=servicelb",
+            "--disable=local-storage",
+            "--disable=metrics-server",
+            "--disable-helm-controller",
+        ]
+    }
+
+    fn expose_ports(&self) -> &[ContainerPort] {
+        &[K3S_API_PORT]
+    }
+}
+
+impl K3s {
+    pub fn new(kubeconfig_folder: impl Into<String>) -> Self {
+        let tag = if let Ok(tag) = std::env::var(K3S_IMAGE_TAG_ENV_VAR) {
+            tag
+        } else {
+            let versions = AVAILABLE_K3S_IMAGE_TAGS
+                .into_iter()
+                .map(|(k, v)| (k, v.to_string()))
+                .collect::<HashMap<&str, String>>();
+            let version =
+                std::env::var(KUBE_VERSION_ENV_VAR).unwrap_or(KUBE_VERSION_DEFAULT.to_string());
+            let version = version.strip_prefix("v").unwrap_or(&version);
+            let version = if version.is_empty() || version == "latest" {
+                KUBE_VERSION_DEFAULT
+            } else {
+                version
+            };
+
+            versions
+                .get(&version)
+                .unwrap_or_else(|| panic!("Kube version '{version}' is not supported"))
+                .to_owned()
+        };
+
+        Self {
+            kubeconfig_folder: Mount::bind_mount(kubeconfig_folder, "/etc/rancher/k3s/"),
+            tag,
+        }
+    }
+
+    pub async fn get_kubeconfig(&self) -> io::Result<String> {
+        let k3s_conf_file_path = self.kubeconfig_folder.source().unwrap();
+        let k3s_conf_file_path = Path::new(k3s_conf_file_path).join("k3s.yaml");
+        tokio::fs::read_to_string(k3s_conf_file_path).await
+    }
+
+    pub async fn get_client(container: &ContainerAsync<K3s>) -> anyhow::Result<kube::Client> {
+        if CryptoProvider::get_default().is_none() {
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .expect("Error initializing rustls provider");
+        }
+
+        let conf_yaml = container.image().get_kubeconfig().await?;
+        let mut config = Kubeconfig::from_yaml(&conf_yaml).expect("Error loading kube config");
+
+        let port = container.get_host_port_ipv4(K3S_API_PORT).await?;
+        config.clusters.iter_mut().for_each(|cluster| {
+            if let Some(server) = cluster.cluster.as_mut().and_then(|c| c.server.as_mut()) {
+                *server = format!("https://127.0.0.1:{port}")
+            }
+        });
+
+        let client_config =
+            Config::from_custom_kubeconfig(config, &KubeConfigOptions::default()).await?;
+
+        Ok(kube::Client::try_from(client_config)?)
+    }
+
+    pub async fn get_kubeconfig_yaml_with_port(
+        container: &ContainerAsync<K3s>,
+    ) -> anyhow::Result<String> {
+        let conf_yaml = container.image().get_kubeconfig().await?;
+        let port = container.get_host_port_ipv4(K3S_API_PORT).await?;
+        Ok(conf_yaml.replace("https://127.0.0.1:6443", &format!("https://127.0.0.1:{port}")))
+    }
+}
+
+pub async fn create_client_from_kubeconfig_yaml(yaml: &str) -> anyhow::Result<kube::Client> {
+    if CryptoProvider::get_default().is_none() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("Error initializing rustls provider");
+    }
+
+    let config = Kubeconfig::from_yaml(yaml).expect("Error loading kube config");
+    let client_config =
+        Config::from_custom_kubeconfig(config, &KubeConfigOptions::default()).await?;
+
+    Ok(kube::Client::try_from(client_config)?)
+}

--- a/tests/common/k3s.rs
+++ b/tests/common/k3s.rs
@@ -87,8 +87,7 @@ impl K3s {
                 .into_iter()
                 .map(|(k, v)| (k, v.to_string()))
                 .collect::<HashMap<&str, String>>();
-            let version =
-                std::env::var(KUBE_VERSION_ENV_VAR).unwrap_or(KUBE_VERSION_DEFAULT.to_string());
+            let version = std::env::var(KUBE_VERSION_ENV_VAR).unwrap_or(KUBE_VERSION_DEFAULT.to_string());
             let version = version.strip_prefix("v").unwrap_or(&version);
             let version = if version.is_empty() || version == "latest" {
                 KUBE_VERSION_DEFAULT
@@ -131,15 +130,12 @@ impl K3s {
             }
         });
 
-        let client_config =
-            Config::from_custom_kubeconfig(config, &KubeConfigOptions::default()).await?;
+        let client_config = Config::from_custom_kubeconfig(config, &KubeConfigOptions::default()).await?;
 
         Ok(kube::Client::try_from(client_config)?)
     }
 
-    pub async fn get_kubeconfig_yaml_with_port(
-        container: &ContainerAsync<K3s>,
-    ) -> anyhow::Result<String> {
+    pub async fn get_kubeconfig_yaml_with_port(container: &ContainerAsync<K3s>) -> anyhow::Result<String> {
         let conf_yaml = container.image().get_kubeconfig().await?;
         let port = container.get_host_port_ipv4(K3S_API_PORT).await?;
         Ok(conf_yaml.replace("https://127.0.0.1:6443", &format!("https://127.0.0.1:{port}")))
@@ -154,8 +150,7 @@ pub async fn create_client_from_kubeconfig_yaml(yaml: &str) -> anyhow::Result<ku
     }
 
     let config = Kubeconfig::from_yaml(yaml).expect("Error loading kube config");
-    let client_config =
-        Config::from_custom_kubeconfig(config, &KubeConfigOptions::default()).await?;
+    let client_config = Config::from_custom_kubeconfig(config, &KubeConfigOptions::default()).await?;
 
     Ok(kube::Client::try_from(client_config)?)
 }

--- a/tests/common/k3s.rs
+++ b/tests/common/k3s.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use kube::{
     Config,
     config::{KubeConfigOptions, Kubeconfig},
@@ -135,6 +133,7 @@ impl K3s {
         Ok(kube::Client::try_from(client_config)?)
     }
 
+    #[allow(dead_code)] // actually it's not dead
     pub async fn get_kubeconfig_yaml_with_port(container: &ContainerAsync<K3s>) -> anyhow::Result<String> {
         let conf_yaml = container.image().get_kubeconfig().await?;
         let port = container.get_host_port_ipv4(K3S_API_PORT).await?;
@@ -142,6 +141,7 @@ impl K3s {
     }
 }
 
+#[allow(dead_code)] // actually it's not dead
 pub async fn create_client_from_kubeconfig_yaml(yaml: &str) -> anyhow::Result<kube::Client> {
     if CryptoProvider::get_default().is_none() {
         rustls::crypto::ring::default_provider()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 pub mod k3s;
 
 use dtor::dtor;
@@ -15,12 +13,14 @@ const DISABLE_CONTAINER_DESTRUCTORS_ENV_NAME: &str = "DISABLE_CONTAINER_DESTRUCT
 
 static K3S_CLUSTER_CONTAINER: OnceCell<RwLock<Option<ContainerAsync<K3s>>>> = OnceCell::const_new();
 
+#[allow(dead_code)] // actually it's not dead
 pub async fn get_test_kube_client() -> anyhow::Result<kube::Client> {
     let guard = get_k3s_cluster().await.read().await;
     let cluster = guard.as_ref().unwrap();
     K3s::get_client(cluster).await
 }
 
+#[allow(dead_code)] // actually it's not dead
 pub async fn get_kubeconfig_yaml() -> anyhow::Result<String> {
     let guard = get_k3s_cluster().await.read().await;
     let cluster = guard.as_ref().unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,79 @@
+#![allow(dead_code)]
+
+pub mod k3s;
+
+use dtor::dtor;
+use k3s::K3s;
+use std::{env, thread};
+use testcontainers::{ContainerAsync, ImageExt as _, runners::AsyncRunner as _};
+use tokio::{
+    runtime::Runtime,
+    sync::{Mutex, OnceCell, RwLock},
+};
+
+const DISABLE_CONTAINER_DESTRUCTORS_ENV_NAME: &str = "DISABLE_CONTAINER_DESTRUCTORS";
+
+static K3S_CLUSTER_CONTAINER: OnceCell<RwLock<Option<ContainerAsync<K3s>>>> = OnceCell::const_new();
+
+pub async fn get_test_kube_client() -> anyhow::Result<kube::Client> {
+    let guard = get_k3s_cluster().await.read().await;
+    let cluster = guard.as_ref().unwrap();
+    K3s::get_client(cluster).await
+}
+
+pub async fn get_kubeconfig_yaml() -> anyhow::Result<String> {
+    let guard = get_k3s_cluster().await.read().await;
+    let cluster = guard.as_ref().unwrap();
+    k3s::K3s::get_kubeconfig_yaml_with_port(cluster).await
+}
+
+async fn get_k3s_cluster() -> &'static RwLock<Option<ContainerAsync<K3s>>> {
+    K3S_CLUSTER_CONTAINER
+        .get_or_init(|| async {
+            if rustls::crypto::CryptoProvider::get_default().is_none() {
+                rustls::crypto::ring::default_provider()
+                    .install_default()
+                    .expect("Error initializing rustls provider");
+            }
+
+            let runtime_folder = std::env::temp_dir()
+                .join(format!("kube-lease-k3s-int-{}", std::process::id()))
+                .to_string_lossy()
+                .into_owned();
+            tokio::fs::create_dir_all(&runtime_folder).await.unwrap();
+
+            let container = K3s::new(runtime_folder)
+                .with_userns_mode("host")
+                .with_privileged(true)
+                .start()
+                .await
+                .unwrap();
+
+            RwLock::new(Some(container))
+        })
+        .await
+}
+
+#[dtor(unsafe)]
+fn shutdown_test_containers() {
+    static LOCK: Mutex<()> = Mutex::const_new(());
+
+    if env::var(DISABLE_CONTAINER_DESTRUCTORS_ENV_NAME).is_err() {
+        let _ = thread::spawn(|| {
+            Runtime::new().unwrap().block_on(async {
+                let _guard = LOCK.lock().await;
+
+                if let Some(k3s) = K3S_CLUSTER_CONTAINER.get() {
+                    let mut k3s = k3s.write().await;
+                    if k3s.is_some() {
+                        let old = (*k3s).take().unwrap();
+                        old.stop().await.unwrap();
+                        old.rm().await.unwrap();
+                        *k3s = None;
+                    }
+                }
+            });
+        })
+        .join();
+    }
+}

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -1,14 +1,14 @@
-use kube::Client;
+mod common;
+
 use kube_lease_manager::{LeaseManagerBuilder, Result};
 use std::time::Duration;
 
 #[tokio::test]
-#[ignore = "uses k8s current-context"]
+#[ignore = "needs docker"]
 async fn manual() -> Result<()> {
-    // Use the default Kube client
-    let client = Client::try_default().await?;
+    let client = common::get_test_kube_client().await.unwrap();
     // Create the simplest LeaseManager with reasonable defaults using a convenient builder.
-    // It uses a Lease resource called `test-watch-lease`.
+    // It uses a Lease resource called `test-manual-lease`.
     let manager = LeaseManagerBuilder::new(client, "test-manual-lease").build().await?;
 
     // Try to get a lock on resource

--- a/tests/watch_many_threads.rs
+++ b/tests/watch_many_threads.rs
@@ -11,6 +11,8 @@
 ///
 /// The requirement is that a channel contains a correct sequence of events.
 ///
+mod common;
+
 use std::{
     sync::mpsc::{self, Sender},
     thread,
@@ -40,15 +42,26 @@ enum Event {
 }
 
 #[test]
-#[ignore = "uses k8s current-context"]
+#[ignore = "needs docker"]
 fn watch_many_threads() -> Result<()> {
     tracing_subscriber::fmt::init();
+
+    // Start the K3s cluster and extract kubeconfig YAML before spawning threads.
+    // Each thread gets its own client from the YAML so it works with its own tokio Runtime.
+    let kubeconfig_yaml = {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(common::get_kubeconfig_yaml()).unwrap()
+    };
 
     let (tx, rx) = mpsc::channel::<Event>();
     let tasks: Vec<_> = (0..TEST_THREADS)
         .map(move |index| {
             let tx = tx.clone();
-            thread::spawn(move || run_watch_tread(index, tx))
+            let yaml = kubeconfig_yaml.clone();
+            thread::spawn(move || run_watch_tread(index, tx, yaml))
         })
         .collect();
 
@@ -83,7 +96,7 @@ fn watch_many_threads() -> Result<()> {
     Ok(())
 }
 
-fn run_watch_tread(index: usize, tx: Sender<Event>) -> Result<()> {
+fn run_watch_tread(index: usize, tx: Sender<Event>, kubeconfig_yaml: String) -> Result<()> {
     debug!(%index, "Starting");
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -92,7 +105,9 @@ fn run_watch_tread(index: usize, tx: Sender<Event>) -> Result<()> {
         .unwrap();
 
     rt.block_on(async move {
-        let client = Client::try_default().await.unwrap();
+        let client = common::k3s::create_client_from_kubeconfig_yaml(&kubeconfig_yaml)
+            .await
+            .unwrap();
         create_namespace(client.clone(), TEST_NAMESPACE).await.unwrap();
 
         let manager = LeaseManagerBuilder::new(client, TEST_LEASE_NAME)
@@ -144,7 +159,6 @@ fn run_watch_tread(index: usize, tx: Sender<Event>) -> Result<()> {
 }
 
 async fn create_namespace(client: Client, namespace: &str) -> Result<()> {
-    // Create namespace
     let pp = PostParams::default();
     let mut data = Namespace::default();
     data.meta_mut().name = Some(String::from(namespace));


### PR DESCRIPTION
## Self-contained test infrastructure using testcontainers

  Replaces the external Kubernetes cluster dependency (previously provisioned via `nolar/setup-k3d-k3s` in CI and required locally) with a testcontainers-managed k3s cluster that spins up on
  demand and tears down automatically.

  **Changes:**
  - `src/tests/` — new shared unit-test helpers: K3s cluster singleton (`OnceCell`), `init()`, `LeaseDropper`, `sleep_secs`, `setup_inconsistent_lease`; cluster shutdown via `dtor`
  - `tests/common/` — same pattern for integration test binaries; adds `get_kubeconfig_yaml()` for the multi-runtime thread test
  - `tests/watch_many_threads.rs` — restructured to start K3s once, distribute kubeconfig YAML to per-thread runtimes
  - `Cargo.toml` — added `dtor = "1.0.4"`, `testcontainers = "0.27.3"`, `rustls` with `ring` feature
  - CI workflows — removed `nolar/setup-k3d-k3s@v1` step; heavy tests now set `CARGO_TEST_KUBE_VERSION` and `DISABLE_CONTAINER_DESTRUCTORS=true`

  **To run ignored tests locally:**
  ```shell
   cargo test --all -- --include-ignored
   ```
  Docker must be running. K3s version is controlled via `CARGO_TEST_KUBE_VERSION` (e.g. `v1.31`, `latest`).